### PR TITLE
feat(Validator): provide handling for validatorPower & totalPower isZero

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2479,6 +2479,16 @@ func (cs *State) calculatePrevoteMessageDelayMetrics() {
 		}
 	}
 	if ps.HasAll() {
+		if len(pl) < 1 {
+			fmt.Printf("ERROR: prevotes.hasAll() but len(prevotes) < 1 in round %d\n", cs.Round)
+			fmt.Printf("prevotes: %v\n", ps)
+			fmt.Printf("votes: %v\n", cs.Votes)
+			fmt.Printf("proposal: %v\n", cs.Proposal)
+			fmt.Printf("lock: %v\n", cs.LockedBlock)
+			fmt.Printf("commit: %v\n", cs.ValidBlock)
+			fmt.Printf("pl %v", pl)
+			return
+		}
 		cs.metrics.FullPrevoteDelay.With("proposer_address", cs.Validators.GetProposer().Address.String()).Set(pl[len(pl)-1].Timestamp.Sub(cs.Proposal.Timestamp).Seconds())
 	}
 }

--- a/types/validation.go
+++ b/types/validation.go
@@ -219,14 +219,14 @@ func verifyCommitBatch(
 
 		// if we don't need to verify all signatures and already have sufficient
 		// voting power we can break from batching and verify all the signatures
-		if !countAllSignatures && talliedVotingPower > votingPowerNeeded {
+		if !countAllSignatures && talliedVotingPower > votingPowerNeeded || (talliedVotingPower == 0 && votingPowerNeeded == 0) {
 			break
 		}
 	}
 
 	// ensure that we have batched together enough signatures to exceed the
 	// voting power needed else there is no need to even verify
-	if got, needed := talliedVotingPower, votingPowerNeeded; got <= needed {
+	if got, needed := talliedVotingPower, votingPowerNeeded; got <= needed && needed > 0 {
 		return ErrNotEnoughVotingPowerSigned{Got: got, Needed: needed}
 	}
 
@@ -319,12 +319,12 @@ func verifyCommitSingle(
 		}
 
 		// check if we have enough signatures and can thus exit early
-		if !countAllSignatures && talliedVotingPower > votingPowerNeeded {
+		if !countAllSignatures && talliedVotingPower > votingPowerNeeded || (talliedVotingPower == 0 && votingPowerNeeded == 0) {
 			return nil
 		}
 	}
 
-	if got, needed := talliedVotingPower, votingPowerNeeded; got <= needed {
+	if got, needed := talliedVotingPower, votingPowerNeeded; got <= needed && needed > 0 {
 		return ErrNotEnoughVotingPowerSigned{Got: got, Needed: needed}
 	}
 


### PR DESCRIPTION
## Description

This PR allows CometBFT to handle the specific case when both talliedVotingPower and votingPowerNeeded are equal to zero. 
Such conditions should only exist for the initial distribution (and thus, stake-free) period (called IDP). 

 ## Related PRs
